### PR TITLE
``hadolint Dockerfile`` 実行時に表示されるDL3045 warningの修正

### DIFF
--- a/03/Dockerfile
+++ b/03/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:alpine
 
-# WORKDIR /
-COPY main.go /.
+WORKDIR /
+COPY main.go .
 RUN go build main.go
 
 CMD ["./main"]

--- a/03/Dockerfile
+++ b/03/Dockerfile
@@ -1,7 +1,9 @@
-FROM golang:alpine
-
+FROM golang:1.24 AS builder
 WORKDIR /
 COPY main.go .
 RUN go build main.go
 
+FROM alpine:3.22
+WORKDIR /
+COPY --from=builder main .
 CMD ["./main"]

--- a/03/Dockerfile
+++ b/03/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:alpine
+
+# WORKDIR /
+COPY main.go /.
+RUN go build main.go
+
+CMD ["./main"]

--- a/03/main.go
+++ b/03/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, world!")
+}

--- a/03/作業ログ.md
+++ b/03/作業ログ.md
@@ -1,0 +1,3 @@
+FROM scratch
+COPY hello /
+CMD ["/hello"]


### PR DESCRIPTION
## なぜやるか
- `hadolint Dockerfile`を実行することで表示されたDL3045 warningを修正するため
## なにをやったのか
- `COPY main.go .`の前に`WORKDIR /`を追加
- `hadolint Dockerfile`実行時にDL3045 warningが表示されないことの確認
- 下記のコード実行時に`Hello, world!`と出力されることの確認
## 動作確認の手順
- docker build 03 -t 03
- docker run 03