### PR TITLE
k8sのmanifestの追加

### DIFF
--- a/aqua.yaml
+++ b/aqua.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-yaml.json
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# checksum:
+#   enabled: true
+#   require_checksum: true
+#   supported_envs:
+#   - all
+registries:
+- type: standard
+  ref: v4.381.1 # renovate: depName=aquaproj/aqua-registry
+packages:
+- name: kubernetes-sigs/kind@v0.29.0
+- name: derailed/k9s@v0.50.6
+- name: kubernetes-sigs/kustomize@kustomize/v5.7.0

--- a/cluster.yaml
+++ b/cluster.yaml
@@ -1,0 +1,10 @@
+# HA 構成の Cluster を作成する
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: control-plane
+- role: control-plane
+- role: worker
+- role: worker
+- role: worker

--- a/db-deployment.yaml
+++ b/db-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mariadb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mariadb
+  template:
+    metadata:
+      labels:
+        app: mariadb
+    spec:
+      containers:
+      - name: mariadb
+        image: mariadb:11.8.1-ubi9-rc
+        ports:
+        - containerPort: 3306
+        envFrom:
+          - secretRef:
+              name: wordpress-secret
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "250m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+        volumeMounts:
+        - name: db-data-storage
+          mountPath: /var/lib/mysql
+      volumes:
+      - name: db-data-storage
+        persistentVolumeClaim:
+          claimName: db-data-pvc

--- a/db-pvc.yaml
+++ b/db-pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: db-data-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/db-service.yaml
+++ b/db-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: db
+spec:
+  type: ClusterIP
+  selector:
+    app: mariadb
+  ports:
+    - protocol: TCP
+      port: 3306
+      targetPort: 3306

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: default
+
+resources:
+- db-deployment.yaml
+- db-pvc.yaml
+- db-service.yaml
+- secret.yaml
+- wp-deployment.yaml
+- wp-pvc.yaml
+- wp-service.yaml

--- a/out.yaml
+++ b/out.yaml
@@ -1,0 +1,142 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: wordpress-secret
+  namespace: default
+stringData:
+  MYSQL_DATABASE: wordpress
+  MYSQL_PASSWORD: password
+  MYSQL_ROOT_PASSWORD: password
+  MYSQL_USER: wordpress_user
+  WORDPRESS_DB_HOST: db:3306
+  WORDPRESS_DB_NAME: wordpress
+  WORDPRESS_DB_PASSWORD: password
+  WORDPRESS_DB_USER: wordpress_user
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: db
+  namespace: default
+spec:
+  ports:
+  - port: 3306
+    protocol: TCP
+    targetPort: 3306
+  selector:
+    app: mariadb
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: wordpress
+  namespace: default
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: wordpress
+  type: ClusterIP
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: db-data-pvc
+  namespace: default
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: wp-data-pvc
+  namespace: default
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mariadb
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mariadb
+  template:
+    metadata:
+      labels:
+        app: mariadb
+    spec:
+      containers:
+      - envFrom:
+        - secretRef:
+            name: wordpress-secret
+        image: mariadb:11.8.1-ubi9-rc
+        name: mariadb
+        ports:
+        - containerPort: 3306
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 250m
+            memory: 256Mi
+        volumeMounts:
+        - mountPath: /var/lib/mysql
+          name: db-data-storage
+      volumes:
+      - name: db-data-storage
+        persistentVolumeClaim:
+          claimName: db-data-pvc
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wordpress
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wordpress
+  template:
+    metadata:
+      labels:
+        app: wordpress
+    spec:
+      containers:
+      - envFrom:
+        - secretRef:
+            name: wordpress-secret
+        image: wordpress:6.8.1-php8.1-apache
+        name: wordpress
+        ports:
+        - containerPort: 80
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 250m
+            memory: 256Mi
+        volumeMounts:
+        - mountPath: /var/www/html
+          name: wp-data-storage
+      volumes:
+      - name: wp-data-storage
+        persistentVolumeClaim:
+          claimName: wp-data-pvc

--- a/secret.yaml
+++ b/secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: wordpress-secret
+stringData:
+  MYSQL_ROOT_PASSWORD: 'password'
+  MYSQL_DATABASE: 'wordpress'
+  MYSQL_USER: 'wordpress_user'
+  MYSQL_PASSWORD: 'password'
+  WORDPRESS_DB_HOST: 'db:3306'
+  WORDPRESS_DB_USER: 'wordpress_user'
+  WORDPRESS_DB_PASSWORD: 'password'
+  WORDPRESS_DB_NAME: 'wordpress'

--- a/wp-deployment.yaml
+++ b/wp-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wordpress
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wordpress
+  template:
+    metadata:
+      labels:
+        app: wordpress
+    spec:
+      containers:
+      - name: wordpress
+        image: wordpress:6.8.1-php8.1-apache
+        ports:
+        - containerPort: 80
+        envFrom:
+          - secretRef:
+              name: wordpress-secret
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "250m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+        volumeMounts:
+        - name: wp-data-storage
+          mountPath: /var/www/html
+      volumes:
+      - name: wp-data-storage
+        persistentVolumeClaim:
+          claimName: wp-data-pvc

--- a/wp-pvc.yaml
+++ b/wp-pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: wp-data-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/wp-service.yaml
+++ b/wp-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: wordpress
+spec:
+  type: ClusterIP
+  selector:
+    app: wordpress
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 80


### PR DESCRIPTION
## なぜやるか
- wordpressのcomposeのファイルをk8sで動くようにするため
## なにをやったのか
- db-deployment.yaml、db-pvc.yaml、db-sercice.yaml、kustomization.yaml、secret.yaml、wp-deployment.yaml、wp-pvc.yaml、wp-service.yamlの作成
## 動作確認の手順
- ``kustomize build . > out.yaml`` と ``kubectl apply -f out.yaml`` の実行
- ``kubectl port-forward service/wordpress 8080:8080`` の実行
- http://localhost:8080/ へのアクセス

起動したwordpressのブラウザのスクリーンショット
<img width="1479" height="900" alt="スクリーンショット 2025-07-23 18 26 09" src="https://github.com/user-attachments/assets/56f8fd18-fb5f-4b59-9a70-d0b28e37977e" />
